### PR TITLE
Fix fatal errors on homepage when Exhibit Builder is not installed/active

### DIFF
--- a/home/featured-records.php
+++ b/home/featured-records.php
@@ -13,12 +13,17 @@ $total_records['collection'] = 0;
 $total_records['exhibit'] = 0;
 
 foreach ($featured_record_types as $featured_record_type) {
+    if ($featured_record_type === 'exhibit' && !plugin_is_active('ExhibitBuilder')) {
+        continue;
+    }
     $total_records[$featured_record_type]++;
 }
 
 foreach ($total_records as $key => $value ) {
     if ($value) {
         $record_ids[$key] = freedom_random_featured_record_ids($key, $value);
+    } else {
+        $record_ids[$key] = array();
     }
 }
 
@@ -41,38 +46,26 @@ foreach ($featured_record_types as $featured_record_type) {
         <?php endif; ?>
             
         <div class="featured-records">
-            <?php if ($total_records[$featured_record_types[0]]) : ?>
+            <?php if ($record_ids[$featured_record_types[0]]) : ?>
                 <!-- Featured Records - Primary -->
                 <ul class="featured featured--primary">
-                    <?php if (($featured_record_types[0] == 'exhibit') && !plugin_is_active('ExhibitBuilder')) : ?>
-                        <?php echo __('Exhibit Builder is not installed.'); ?>
-                    <?php elseif ($record_ids[$featured_record_types[0]]) : ?>
-                        <?php echo freedom_featured_record_html($featured_record_types[0], $record_ids[$featured_record_types[0]][0], true); ?>
-                        <?php array_shift($record_ids[$featured_record_types[0]]); ?>
-                    <?php endif; ?>
+                    <?php echo freedom_featured_record_html($featured_record_types[0], $record_ids[$featured_record_types[0]][0], true); ?>
+                    <?php array_shift($record_ids[$featured_record_types[0]]); ?>
                 </ul>
             <?php endif; ?>
 
             <!-- Featured Records - Secondary -->
             <ul class="featured featured--secondary">
 
-                <?php if ($total_records[$featured_record_types[1]]) : ?>
+                <?php if ($record_ids[$featured_record_types[1]]) : ?>
                     <!-- Featured Record -->
-                    <?php if (($featured_record_types[1] == 'exhibit') && !plugin_is_active('ExhibitBuilder')) : ?>
-                        <?php echo __('Exhibit Builder is not installed.'); ?>
-                    <?php elseif ($record_ids[$featured_record_types[1]]) : ?>
-                        <?php echo freedom_featured_record_html($featured_record_types[1], $record_ids[$featured_record_types[1]][0]); ?>
-                        <?php array_shift($record_ids[$featured_record_types[1]]); ?>
-                    <?php endif; ?>
+                    <?php echo freedom_featured_record_html($featured_record_types[1], $record_ids[$featured_record_types[1]][0]); ?>
+                    <?php array_shift($record_ids[$featured_record_types[1]]); ?>
                 <?php endif; ?>
 
-                <?php if ($total_records[$featured_record_types[2]]) : ?>
+                <?php if ($record_ids[$featured_record_types[2]]) : ?>
                     <!-- Featured Record -->
-                    <?php if (($featured_record_types[2] == 'exhibit') && !plugin_is_active('ExhibitBuilder')) : ?>
-                        <?php echo __('Exhibit Builder is not installed.'); ?>
-                    <?php elseif ($record_ids[$featured_record_types[2]]) : ?>
-                        <?php echo freedom_featured_record_html($featured_record_types[2], $record_ids[$featured_record_types[2]][0]); ?>
-                    <?php endif; ?>
+                    <?php echo freedom_featured_record_html($featured_record_types[2], $record_ids[$featured_record_types[2]][0]); ?>
                 <?php endif; ?>
 
             </ul>

--- a/home/recent-records.php
+++ b/home/recent-records.php
@@ -8,7 +8,7 @@ $default_recent_types = ['item', 'collection', 'exhibit'];
 for ($i=0; $i < 3; $i++) {
     $recent_type = get_theme_option('homepage_recent_type_' . ($i+1)) ?? $default_recent_types[$i];
 
-    if ($recent_type !== 'none') {
+    if ($recent_type !== 'none' && !($recent_type === 'exhibit' && !plugin_is_active('ExhibitBuilder'))) {
         $recent_title = get_theme_option('homepage_recent_title_' . ($i+1)) ?? 'Recently Added ' . ucfirst($default_recent_types[$i]) . 's';
         $recent_records_count = get_theme_option('homepage_recent_records_count_' . ($i+1));
 


### PR DESCRIPTION
The featured and recent records features don't properly check for whether Exhibit Builder is installed and active, leading to fatal errors on the homepage.